### PR TITLE
Rewrite getConnectionName method

### DIFF
--- a/src/Service/MigratorParser.php
+++ b/src/Service/MigratorParser.php
@@ -41,33 +41,11 @@ class MigratorParser
     public function getConnectionName()
     {
         $file = database_path('migrations'.DIRECTORY_SEPARATOR.$this->name);
+        $migrationObject = (function () use ($file) {
+            return $this->resolvePath($file);
+        })->call(app('migrator'));
 
-        $contents = file_get_contents($file);
-
-        $searchForOne = '$connection';
-        $searchForTwo = 'Schema::connection';
-
-        $patternOne = preg_quote($searchForOne, '/');
-        $patternOne = "/^.*$patternOne.*\$/m";
-
-        $patternTwo = preg_quote($searchForTwo, '/');
-        $patternTwo = "/^.*$patternTwo.*\$/m";
-
-        if (preg_match($patternOne, $contents, $matches)){
-            $match = trim(implode("\n", $matches));
-            $match = str_replace('"', "'", $match);
-
-            return substr($match, stripos($match, "'") + 1, (strripos($match, "'") - stripos($match, "'")) - 1);
-        }
-
-        if(preg_match($patternTwo, $contents, $matches)){
-            $match = trim(implode("\n", $matches));
-            preg_match('/Schema::connection\(["|\'](.*?)["|\']\)/', $match, $m);
-
-            return $m[1] ?? '';
-        }
-
-        return \Config::get('database.default');
+        return $migrationObject->getConnection() ?: config('database.default');
     }
 
     public function getStructure()

--- a/tests/Dependencies/database/migrations/2014_11_32_53600_create_users_table.php
+++ b/tests/Dependencies/database/migrations/2014_11_32_53600_create_users_table.php
@@ -4,14 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class UsersWithConnection extends Migration
+class CreateUsersTable extends Migration
 {
-    /**
-     * The database connection that should be used by the migration.
-     *
-     * @var string
-     */
-    protected $connection = 'pgsql';
 
     /**
      * Run the migrations.
@@ -20,7 +14,7 @@ class UsersWithConnection extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('user', function (Blueprint $table) {
             //
         });
     }
@@ -32,7 +26,7 @@ class UsersWithConnection extends Migration
      */
     public function down()
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('user', function (Blueprint $table) {
             //
         });
     }

--- a/tests/Dependencies/database/migrations/2014_11_32_53601_create_posts_table.php
+++ b/tests/Dependencies/database/migrations/2014_11_32_53601_create_posts_table.php
@@ -4,8 +4,14 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class User extends Migration
+class CreatePostsTable extends Migration
 {
+    /**
+     * The database connection that should be used by the migration.
+     *
+     * @var string
+     */
+    protected $connection = 'custom_connection';
 
     /**
      * Run the migrations.
@@ -14,7 +20,7 @@ class User extends Migration
      */
     public function up()
     {
-        Schema::table('user', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table) {
             //
         });
     }
@@ -26,7 +32,7 @@ class User extends Migration
      */
     public function down()
     {
-        Schema::table('user', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table) {
             //
         });
     }

--- a/tests/Dependencies/database/migrations/2014_11_32_53602_update_posts_table.php
+++ b/tests/Dependencies/database/migrations/2014_11_32_53602_update_posts_table.php
@@ -4,8 +4,13 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class UsersWithConnection extends Migration
+class UpdatePostsTable extends Migration
 {
+    public function __construct()
+    {
+        $this->connection = 'Hello_world';
+    }
+
     /**
      * Run the migrations.
      *

--- a/tests/integration/MigratorParserTest.php
+++ b/tests/integration/MigratorParserTest.php
@@ -2,24 +2,34 @@
 
 namespace MigratorTest\integration;
 
-use MigratorTest\TestCase;
 use Migrator\Service\MigratorParser;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Foundation\Application;
+use MigratorTest\TestCase;
 
 class MigratorParserTest extends TestCase
 {
     /** @test * */
-    public function connection_will_be_returned_default_value(){
-        $app = new Application;
-        $app->useDatabasePath(__DIR__.'/../Dependencies/database');
+    public function connection_will_be_returned_default_value()
+    {
+        // arrange
+        app()->useDatabasePath(__DIR__.'/../Dependencies/database');
+        config()->set('database.default', 'example_connection');
 
-        Config::shouldReceive('get')
-            ->with('database.default')
-            ->once()
-            ->andReturn('test_database');
+        //act
+        $parser = new MigratorParser('2014_11_32_53600_create_users_table.php');
 
-        $parser = new MigratorParser('user.php');
-        $this->assertEquals($parser->getConnectionName(), 'test_database');
+        // assert
+        $this->assertEquals($parser->getConnectionName(), 'example_connection');
+    }
+
+    /** @test * */
+    public function migration_connection_will_be_parsed()
+    {
+        app()->useDatabasePath(__DIR__.'/../Dependencies/database');
+
+        $parser = new MigratorParser('2014_11_32_53601_create_posts_table.php');
+        $this->assertEquals($parser->getConnectionName(), 'custom_connection');
+
+        $parser = new MigratorParser('2014_11_32_53602_update_posts_table.php');
+        $this->assertEquals($parser->getConnectionName(), 'Hello_world');
     }
 }

--- a/tests/unit/MigratorParserTest.php
+++ b/tests/unit/MigratorParserTest.php
@@ -7,7 +7,6 @@ namespace MigratorTest\unit;
 use Migrator\Service\MigratorParser;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Carbon;
-use Illuminate\Foundation\Application;
 
 class MigratorParserTest extends TestCase
 {
@@ -32,17 +31,4 @@ class MigratorParserTest extends TestCase
         Carbon::setTestNow(Carbon::create(2022, 9, 15));
         $this->assertEquals($parser->getDate(), "1 year ago");
     }
-
-    /** @test * */
-    public function migration_connection_will_be_parsed(){
-        $app = new Application;
-        $app->useDatabasePath(__DIR__.'/../Dependencies/database');
-
-        $parser = new MigratorParser('users_with_connection1.php');
-        $this->assertEquals($parser->getConnectionName(), 'pgsql');
-
-        $parser = new MigratorParser('users_with_connection2.php');
-        $this->assertEquals($parser->getConnectionName(), 'pgsql');
-    }
-
 }


### PR DESCRIPTION
Reading code is a crappy way to inspect the class.

For example, what if the user decides to set the $connection from the class constructor based on some custom `if/else` logic?
```php
function __construct () {
   if (....) { 
        $this->connection = '...';
    } else { ... }
}
```


So it is better to create an object from the migration class (In the way laravel internally does when it is doing the migration) and see what is the final value of the property is.